### PR TITLE
Return JSON instead of raw text for /auth/{id} to be consistent with other routes.

### DIFF
--- a/ferrischat_redis/src/lib.rs
+++ b/ferrischat_redis/src/lib.rs
@@ -1,5 +1,1 @@
-
-
-pub fn load_redis() -> _ {
-
-}
+pub fn load_redis() -> _ {}

--- a/ferrischat_webserver/src/auth/get_token.rs
+++ b/ferrischat_webserver/src/auth/get_token.rs
@@ -1,7 +1,7 @@
 use crate::auth::token_gen::generate_random_bits;
 use actix_web::web::HttpResponse;
 use actix_web::{HttpRequest, Responder};
-use ferrischat_common::types::InternalServerErrorJson;
+use ferrischat_common::types::{AuthResponse, InternalServerErrorJson};
 use ferrischat_macros::{get_db_or_fail, get_item_id};
 use num_traits::FromPrimitive;
 use sqlx::types::BigDecimal;
@@ -58,9 +58,11 @@ pub async fn get_token(req: HttpRequest) -> impl Responder {
         })
     };
 
-    return HttpResponse::Ok().body(format!(
+    return HttpResponse::Ok().json(AuthResponse {
+        token: format!(
         "{}.{}",
         base64::encode_config(user_id.to_string(), base64::URL_SAFE),
         token,
-    ));
+    )}
+    );
 }

--- a/ferrischat_webserver/src/auth/get_token.rs
+++ b/ferrischat_webserver/src/auth/get_token.rs
@@ -60,9 +60,9 @@ pub async fn get_token(req: HttpRequest) -> impl Responder {
 
     return HttpResponse::Ok().json(AuthResponse {
         token: format!(
-        "{}.{}",
-        base64::encode_config(user_id.to_string(), base64::URL_SAFE),
-        token,
-    )}
-    );
+            "{}.{}",
+            base64::encode_config(user_id.to_string(), base64::URL_SAFE),
+            token,
+        ),
+    });
 }


### PR DESCRIPTION
See also [Common #3 ](https://github.com/FerrisChat/Common/pull/3)