### PR TITLE
Update to Rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ferrischat_server"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = ["FerrisChat Team <crates@ferris.chat>"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/ferrischat_auth/Cargo.toml
+++ b/ferrischat_auth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ferrischat_auth"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/ferrischat_db/Cargo.toml
+++ b/ferrischat_db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ferrischat_db"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 description = "Database utilities for FerrisChat"
 license = "EUPL-1.2"
 homepage = "https://ferris.chat"

--- a/ferrischat_macros/Cargo.toml
+++ b/ferrischat_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ferrischat_macros"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 description = "Macro utilities for FerrisChat"
 license = "EUPL-1.2"
 homepage = "https://ferris.chat"

--- a/ferrischat_webserver/Cargo.toml
+++ b/ferrischat_webserver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ferrischat_webserver"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 description = "The core FerrisChat webserver and docs"
 license = "EUPL-1.2"
 homepage = "https://ferris.chat"
@@ -36,7 +36,7 @@ tokio-tungstenite = "0.15"
 simd-json = { version = "0.4", features = ["128bit"] }
 
 ferrischat_db = { path = "../ferrischat_db", version = "0.1" }
-ferrischat_common = { git = "https://github.com/FerrisChat/Common.git", version = "0.1", branch = "master" }
+ferrischat_common = { git = "https://github.com/FerrisChat/Common.git", version = "0.2", branch = "master" }
 ferrischat_macros = { path = "../ferrischat_macros", version = "0.1" }
 ferrischat_redis = { path = "../ferrischat_redis", version = "0.1"}
 ferrischat_ws = { path = "../ferrischat_ws", version = "0.1" }

--- a/ferrischat_ws/Cargo.toml
+++ b/ferrischat_ws/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ferrischat_ws"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This PR aims to update the Server to Rust 2021 Edition for consistency with other projects/libraries.

A few notes:

- A complete list of changes to Rust 2021 can be found [here](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html)
- This code currently builds successfully on my local machine (running latest git revision), but dumps **WAY** more warnings (mostly used X) than Rust 2018.
- ANY new commits to `origin/develop` will be merged into this branch.

**Contributors/Maintainers:** Feel free to commit to this branch and co-author this PR to make any changes to the codebase before merge. 