### PR TITLE
Increase max_connections too because why not

### DIFF
--- a/ferrischat_webserver/src/entrypoint.rs
+++ b/ferrischat_webserver/src/entrypoint.rs
@@ -186,6 +186,7 @@ pub async fn entrypoint() {
             )
             .default_service(web::route().to(HttpResponse::NotFound))
     })
+    .max_connections(250_000)
     .max_connection_rate(8192)
     .bind("0.0.0.0:8080")
     .expect("failed to bind to 0.0.0.0:8080")


### PR DESCRIPTION
According to ferris hyper bongo, increasing max_connections is critical for FerrisChat:tm: to archive success, and in order to overcome this obstacle I suggest we shall increase max_connections to 1 million which is 1,000,000, but sadly this such pogger idea got decline by @tazz4843 so the best strategy I shall take is increasing it to 250,000 