### PR TITLE
Add email verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,7 +1285,7 @@ dependencies = [
  "simd-json",
  "sqlx",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.22.0",
  "tokio-tungstenite",
  "tracing",
  "uuid",
@@ -1843,18 +1843,14 @@ version = "0.10.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d8da8f34d086b081c9cc3b57d3bb3b51d16fc06b5c848a188e2f14d58ac2a5"
 dependencies = [
- "base64 0.13.0",
- "fastrand",
+ "async-trait",
+ "futures-io",
  "futures-util",
- "hostname 0.3.1",
- "httpdate",
  "idna",
- "mime",
- "native-tls",
- "nom 7.1.0",
  "once_cell",
- "quoted_printable",
  "regex",
+ "tokio",
+ "tokio-rustls 0.23.1",
 ]
 
 [[package]]
@@ -2364,12 +2360,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quoted_printable"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1238256b09923649ec89b08104c4dfe9f6cb2fea734a5db5384e44916d59e9c5"
-
-[[package]]
 name = "rand"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,8 +2713,20 @@ dependencies = [
  "base64 0.13.0",
  "log",
  "ring",
- "sct",
- "webpki",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac4581f0fc0e0efd529d069e8189ec7b90b8e7680e21beb35141bdc45f36040"
+dependencies = [
+ "log",
+ "ring",
+ "sct 0.7.0",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -2760,6 +2762,16 @@ name = "sct"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -3032,7 +3044,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "rand 0.8.4",
- "rustls",
+ "rustls 0.19.1",
  "serde",
  "serde_json",
  "sha-1",
@@ -3045,7 +3057,7 @@ dependencies = [
  "time 0.2.27",
  "tokio-stream",
  "url",
- "webpki",
+ "webpki 0.21.4",
  "webpki-roots",
  "whoami",
 ]
@@ -3081,7 +3093,7 @@ dependencies = [
  "actix-rt",
  "once_cell",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.22.0",
 ]
 
 [[package]]
@@ -3381,9 +3393,20 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
- "rustls",
+ "rustls 0.19.1",
  "tokio",
- "webpki",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4baa378e417d780beff82bf54ceb0d195193ea6a00c14e22359e7f39456b5689"
+dependencies = [
+ "rustls 0.20.1",
+ "tokio",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -3797,12 +3820,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
- "webpki",
+ "webpki 0.21.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1856,8 +1856,11 @@ dependencies = [
  "once_cell",
  "quoted_printable",
  "regex",
+ "rustls 0.20.1",
+ "rustls-pemfile",
  "tokio",
  "tokio-rustls 0.23.1",
+ "webpki-roots 0.22.1",
 ]
 
 [[package]]
@@ -2743,6 +2746,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64 0.13.0",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3071,7 +3083,7 @@ dependencies = [
  "tokio-stream",
  "url",
  "webpki 0.21.4",
- "webpki-roots",
+ "webpki-roots 0.21.1",
  "whoami",
 ]
 
@@ -3849,6 +3861,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
  "webpki 0.21.4",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c475786c6f47219345717a043a37ec04cb4bc185e28853adcc4fa0a947eba630"
+dependencies = [
+ "webpki 0.22.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 [[package]]
 name = "actix-codec"
 version = "0.4.1"
-source = "git+https://github.com/actix/actix-net#443a328fb44a996349c4e3979bf0acf3ddd65b8d"
+source = "git+https://github.com/actix/actix-net#7e7df2f9316900acc258bbe56485a07c138deaf5"
 dependencies = [
  "bitflags",
  "bytes",
@@ -44,7 +44,7 @@ dependencies = [
 [[package]]
 name = "actix-http"
 version = "3.0.0-beta.12"
-source = "git+https://github.com/actix/actix-web/#a2f59c02f72c0c50cb69dd9e17439f70b6a8b6db"
+source = "git+https://github.com/actix/actix-web/#e8a0e168636a439a2eb37323f4acb22be685116a"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -156,7 +156,7 @@ dependencies = [
 [[package]]
 name = "actix-web"
 version = "4.0.0-beta.11"
-source = "git+https://github.com/actix/actix-web/#a2f59c02f72c0c50cb69dd9e17439f70b6a8b6db"
+source = "git+https://github.com/actix/actix-web/#e8a0e168636a439a2eb37323f4acb22be685116a"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -196,7 +196,7 @@ dependencies = [
 [[package]]
 name = "actix-web-actors"
 version = "4.0.0-beta.7"
-source = "git+https://github.com/actix/actix-web/#a2f59c02f72c0c50cb69dd9e17439f70b6a8b6db"
+source = "git+https://github.com/actix/actix-web/#e8a0e168636a439a2eb37323f4acb22be685116a"
 dependencies = [
  "actix",
  "actix-codec",
@@ -284,9 +284,9 @@ checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
 name = "arc-swap"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6df5aef5c5830360ce5218cecb8f018af3438af5686ae945094affc86fdec63"
+checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
 
 [[package]]
 name = "argonautica"
@@ -3361,9 +3361,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
+checksum = "52963f91310c08d91cb7bff5786dfc8b79642ab839e188187e92105dbfb9d2c8"
 dependencies = [
  "autocfg 1.0.1",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ dependencies = [
  "log",
  "mio",
  "num_cpus",
- "socket2",
+ "socket2 0.4.2",
  "tokio",
 ]
 
@@ -188,7 +188,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2",
+ "socket2 0.4.2",
  "time 0.3.5",
  "url",
 ]
@@ -277,6 +277,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
+
+[[package]]
 name = "arc-swap"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +313,197 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "ascii_utils"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
+
+[[package]]
+name = "async-channel"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9586ec52317f36de58453159d48351bc244bc24ced3effc1fce22f3d48664af6"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-io",
+ "async-mutex",
+ "blocking",
+ "futures-lite",
+ "num_cpus",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a811e6a479f2439f0c04038796b5cfb3d2ad56c230e0f2d3f7b04d68cfee607b"
+dependencies = [
+ "concurrent-queue",
+ "futures-lite",
+ "libc",
+ "log",
+ "once_cell",
+ "parking",
+ "polling",
+ "slab",
+ "socket2 0.4.2",
+ "waker-fn",
+ "winapi",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6a8ea61bf9947a1007c5cada31e647dbc77b103c679858150003ba697ea798b"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-mutex"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-native-tls"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e9e7a929bd34c68a82d58a4de7f86fffdaf97fb2af850162a7bb19dd7269b33"
+dependencies = [
+ "async-std",
+ "native-tls",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "async-process"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83137067e3a2a6a06d67168e49e68a0957d215410473a740cea95a2425c0b7c6"
+dependencies = [
+ "async-io",
+ "blocking",
+ "cfg-if 1.0.0",
+ "event-listener",
+ "futures-lite",
+ "libc",
+ "once_cell",
+ "signal-hook",
+ "winapi",
+]
+
+[[package]]
+name = "async-smtp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "472a081e9e3a92f9201237f07b51c0bab657336ca6600fd2f243c9cc3c9c81ff"
+dependencies = [
+ "async-native-tls",
+ "async-std",
+ "async-trait",
+ "base64 0.13.0",
+ "bufstream",
+ "fast-socks5",
+ "fast_chemail",
+ "hostname 0.1.5",
+ "log",
+ "nom 5.1.2",
+ "pin-project",
+ "pin-utils",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "async-std"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8056f1455169ab86dd47b47391e4ab0cbd25410a70e9fe675544f49bafaf952"
+dependencies = [
+ "async-channel",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-std-resolver"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed4e2c3da14d8ad45acb1e3191db7a918e9505b6f155b218e70a7c9a1a48c638"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "futures-io",
+ "futures-util",
+ "pin-utils",
+ "trust-dns-resolver",
+]
+
+[[package]]
+name = "async-task"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
+
+[[package]]
 name = "async-trait"
 version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +522,12 @@ checksum = "616896e05fc0e2649463a93a15183c6a16bf03413a7af88ef1285ddedfa9cda5"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atty"
@@ -433,6 +636,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046e47d4b2d391b1f6f8b407b1deb8dee56c1852ccd868becf2710f601b5f427"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
 name = "brotli-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,6 +668,12 @@ dependencies = [
  "brotli-sys",
  "libc",
 ]
+
+[[package]]
+name = "bufstream"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40e38929add23cdf8a366df9b0e088953150724bcbe5fc330b0d8eb3b328eec8"
 
 [[package]]
 name = "bumpalo"
@@ -478,6 +701,12 @@ checksum = "90706ba19e97b90786e19dc0d5e2abd80008d99d4c0c5d1ad0b5e72cec7c494d"
 dependencies = [
  "bytes",
 ]
+
+[[package]]
+name = "cache-padded"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
@@ -508,6 +737,28 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "check-if-email-exists"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fbaa7cd916f5000cd377f60ab4333dd6a4ee970364637f7ceaa18e5faf9be1"
+dependencies = [
+ "async-native-tls",
+ "async-smtp",
+ "async-std",
+ "async-std-resolver",
+ "fast-socks5",
+ "futures 0.3.17",
+ "log",
+ "mailchecker",
+ "rand 0.8.4",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "trust-dns-proto",
+]
 
 [[package]]
 name = "clang-sys"
@@ -559,6 +810,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +839,16 @@ dependencies = [
  "percent-encoding",
  "time 0.2.27",
  "version_check 0.9.3",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -685,6 +955,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
+dependencies = [
+ "quote 1.0.10",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +973,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "num_cpus",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "derive_more"
@@ -773,6 +1059,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,6 +1097,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+
+[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,6 +1122,37 @@ dependencies = [
  "quote 1.0.10",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "fast-socks5"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba337793c1ee49731350a8d971d791651ed51d6e814ab4ddabd79c12b5366140"
+dependencies = [
+ "anyhow",
+ "async-std",
+ "futures 0.3.17",
+ "log",
+ "thiserror",
+]
+
+[[package]]
+name = "fast_chemail"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "495a39d30d624c2caabe6312bfead73e7717692b44e0b32df168c275a2e8e9e4"
+dependencies = [
+ "ascii_utils",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -907,6 +1242,7 @@ dependencies = [
  "actix-web-actors",
  "base64 0.13.0",
  "bytes",
+ "check-if-email-exists",
  "dotenv",
  "ferrischat_auth",
  "ferrischat_common",
@@ -918,6 +1254,7 @@ dependencies = [
  "futures 0.3.17",
  "futures-cpupool",
  "http",
+ "lettre",
  "libc",
  "nix",
  "num-bigint",
@@ -986,6 +1323,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1079,6 +1431,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
 
 [[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,6 +1523,19 @@ name = "glob"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "h2"
@@ -1249,6 +1629,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
+dependencies = [
+ "libc",
+ "winutil",
+]
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
+]
+
+[[package]]
 name = "http"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1658,17 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1287,6 +1699,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "hyper"
+version = "0.14.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b91bb1f221b6ea1f1e4371216b70f40748774c2fb5971b450c07773fb92d26b"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.4.2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,6 +1764,24 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
 ]
+
+[[package]]
+name = "ipconfig"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
+dependencies = [
+ "socket2 0.3.19",
+ "widestring",
+ "winapi",
+ "winreg 0.6.2",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
@@ -1350,6 +1817,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1836,39 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lettre"
+version = "0.10.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d8da8f34d086b081c9cc3b57d3bb3b51d16fc06b5c848a188e2f14d58ac2a5"
+dependencies = [
+ "base64 0.13.0",
+ "fastrand",
+ "futures-util",
+ "hostname 0.3.1",
+ "httpdate",
+ "idna",
+ "mime",
+ "native-tls",
+ "nom 7.1.0",
+ "once_cell",
+ "quoted_printable",
+ "regex",
+]
+
+[[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if 1.0.0",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "libc"
@@ -1376,6 +1885,12 @@ dependencies = [
  "cc",
  "winapi",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "local-channel"
@@ -1411,7 +1926,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
+ "value-bag",
 ]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
+name = "mailchecker"
+version = "4.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d012c79f38febe303bfc81289a1d9a90d1844225a335568b6241317419368b"
+dependencies = [
+ "fast_chemail",
+]
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matches"
@@ -1490,6 +2030,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nix"
 version = "0.23.0"
 source = "git+https://github.com/nix-rust/nix#57d4c863ab3d1b25a58f6ebeea36bcb8fadcf36b"
@@ -1509,6 +2067,17 @@ checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 dependencies = [
  "memchr",
  "version_check 0.1.5",
+]
+
+[[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -1591,6 +2160,45 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6517987b3f8226b5da3661dad65ff7f300cc59fb5ea8333ca191fc65fde3edf"
+dependencies = [
+ "autocfg 1.0.1",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
@@ -1677,6 +2285,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
+
+[[package]]
+name = "polling"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "log",
+ "wepoll-ffi",
+ "winapi",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1735,6 +2362,12 @@ checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2 1.0.32",
 ]
+
+[[package]]
+name = "quoted_printable"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1238256b09923649ec89b08104c4dfe9f6cb2fea734a5db5384e44916d59e9c5"
 
 [[package]]
 name = "rand"
@@ -1997,6 +2630,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d2927ca2f685faf0fc620ac4834690d29e7abb153add10f5812eef20b5e280"
+dependencies = [
+ "base64 0.13.0",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-socks",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.7.0",
+]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
+dependencies = [
+ "hostname 0.3.1",
+ "quick-error",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,6 +2734,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "scopeguard"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,6 +2763,29 @@ checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2186,6 +2898,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c98891d737e271a2954825ef19e46bd16bdb98e2746f2eec4f7a4ef7946efd1"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2224,6 +2946,17 @@ name = "smallvec"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+
+[[package]]
+name = "socket2"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "socket2"
@@ -2361,6 +3094,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stdweb"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2477,6 +3216,20 @@ checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
  "rand 0.4.6",
  "remove_dir_all",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "rand 0.8.4",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -2613,6 +3366,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2621,6 +3384,18 @@ dependencies = [
  "rustls",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -2671,6 +3446,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-service"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+
+[[package]]
 name = "tracing"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2701,6 +3482,56 @@ checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "trust-dns-proto"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0d7f5db438199a6e2609debe3f69f808d074e0a2888ee0bccb45fe234d03f4"
+dependencies = [
+ "async-trait",
+ "cfg-if 1.0.0",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "lazy_static",
+ "log",
+ "rand 0.8.4",
+ "smallvec",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ad17b608a64bd0735e67bde16b0636f8aa8591f831a25d18443ed00a699770"
+dependencies = [
+ "cfg-if 1.0.0",
+ "futures-util",
+ "ipconfig",
+ "lazy_static",
+ "log",
+ "lru-cache",
+ "parking_lot",
+ "resolv-conf",
+ "smallvec",
+ "thiserror",
+ "trust-dns-proto",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tungstenite"
@@ -2812,6 +3643,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "value-bag"
+version = "1.0.0-alpha.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79923f7731dc61ebfba3633098bf3ac533bbd35ccd8c57e7088d9a5eebe0263f"
+dependencies = [
+ "ctor",
+ "version_check 0.9.3",
+]
+
+[[package]]
 name = "value-trait"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2822,6 +3663,12 @@ dependencies = [
  "itoa",
  "ryu",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -2840,6 +3687,22 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -2870,6 +3733,18 @@ dependencies = [
  "quote 1.0.10",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2931,6 +3806,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wepoll-ffi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "which"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2949,6 +3833,12 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
 ]
+
+[[package]]
+name = "widestring"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
 name = "winapi"
@@ -2980,6 +3870,33 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winutil"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,10 +1844,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d8da8f34d086b081c9cc3b57d3bb3b51d16fc06b5c848a188e2f14d58ac2a5"
 dependencies = [
  "async-trait",
+ "base64 0.13.0",
+ "fastrand",
  "futures-io",
  "futures-util",
+ "hostname 0.3.1",
+ "httpdate",
  "idna",
+ "mime",
+ "nom 7.1.0",
  "once_cell",
+ "quoted_printable",
  "regex",
  "tokio",
  "tokio-rustls 0.23.1",
@@ -2358,6 +2365,12 @@ checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2 1.0.32",
 ]
+
+[[package]]
+name = "quoted_printable"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1238256b09923649ec89b08104c4dfe9f6cb2fea734a5db5384e44916d59e9c5"
 
 [[package]]
 name = "rand"

--- a/README.md
+++ b/README.md
@@ -46,3 +46,5 @@ cat /proc/cpuinfo | grep pclmulqdq # This one is required for simd-json to compi
 cat /proc/cpuinfo | grep avx2      # Either this one or...
 cat /proc/cpuinfo | grep sse4_2    # this one are required as well as pclmulqdq
 ```
+### What operating systems do you support?
+For the client.... almost all of them. For the server, Linux and FreeBSD are supported.

--- a/ferrischat_webserver/Cargo.toml
+++ b/ferrischat_webserver/Cargo.toml
@@ -33,7 +33,7 @@ nix = { git = "https://github.com/nix-rust/nix" }
 http = "0.2"
 bytes = "*"
 tokio-tungstenite = "0.15"
-lettre = "0.10.0-rc.4"
+lettre = { version = "0.10.0-rc.4", features = ["tokio1","tokio1_rustls"] }
 check-if-email-exists = "0.8"
 simd-json = { version = "0.4", features = ["128bit"] }
 

--- a/ferrischat_webserver/Cargo.toml
+++ b/ferrischat_webserver/Cargo.toml
@@ -33,7 +33,7 @@ nix = { git = "https://github.com/nix-rust/nix" }
 http = "0.2"
 bytes = "*"
 tokio-tungstenite = "0.15"
-lettre = { version = "0.10.0-rc.4", features = ["tokio1","tokio1_rustls"], default-features = false }
+lettre = { version = "0.10.0-rc.4", features = ["tokio1", "tokio1_rustls", "builder", "pool", "hostname", "smtp-transport"], default-features = false }
 check-if-email-exists = "0.8"
 simd-json = { version = "0.4", features = ["128bit"] }
 

--- a/ferrischat_webserver/Cargo.toml
+++ b/ferrischat_webserver/Cargo.toml
@@ -33,7 +33,7 @@ nix = { git = "https://github.com/nix-rust/nix" }
 http = "0.2"
 bytes = "*"
 tokio-tungstenite = "0.15"
-lettre = { version = "0.10.0-rc.4", features = ["tokio1", "tokio1_rustls", "builder", "pool", "hostname", "smtp-transport"], default-features = false }
+lettre = { version = "0.10.0-rc.4", features = ["tokio1", "tokio1_rustls", "tokio1-rustls-tls", "builder", "pool", "hostname", "smtp-transport"], default-features = false }
 check-if-email-exists = "0.8"
 simd-json = { version = "0.4", features = ["128bit"] }
 

--- a/ferrischat_webserver/Cargo.toml
+++ b/ferrischat_webserver/Cargo.toml
@@ -33,6 +33,8 @@ nix = { git = "https://github.com/nix-rust/nix" }
 http = "0.2"
 bytes = "*"
 tokio-tungstenite = "0.15"
+lettre = "0.10.0-rc.4"
+check-if-email-exists = "0.8"
 simd-json = { version = "0.4", features = ["128bit"] }
 
 ferrischat_db = { path = "../ferrischat_db", version = "0.1" }

--- a/ferrischat_webserver/Cargo.toml
+++ b/ferrischat_webserver/Cargo.toml
@@ -33,7 +33,7 @@ nix = { git = "https://github.com/nix-rust/nix" }
 http = "0.2"
 bytes = "*"
 tokio-tungstenite = "0.15"
-lettre = { version = "0.10.0-rc.4", features = ["tokio1","tokio1_rustls"] }
+lettre = { version = "0.10.0-rc.4", features = ["tokio1","tokio1_rustls"], default-features = false }
 check-if-email-exists = "0.8"
 simd-json = { version = "0.4", features = ["128bit"] }
 

--- a/ferrischat_webserver/src/auth/mod.rs
+++ b/ferrischat_webserver/src/auth/mod.rs
@@ -4,3 +4,4 @@ mod token_gen;
 
 pub use auth_struct::Authorization;
 pub use get_token::*;
+pub use token_gen::*;

--- a/ferrischat_webserver/src/entrypoint.rs
+++ b/ferrischat_webserver/src/entrypoint.rs
@@ -1,3 +1,13 @@
+use actix_web::http::StatusCode;
+use actix_web::{web, App, HttpResponse, HttpServer};
+use ring::rand::{SecureRandom, SystemRandom};
+
+use ferrischat_auth::init_auth;
+use ferrischat_db::load_db;
+use ferrischat_macros::expand_version;
+use ferrischat_redis::load_redis;
+use ferrischat_ws::{init_ws_server, preload_ws};
+
 use crate::auth::get_token;
 use crate::channels::*;
 use crate::guilds::*;
@@ -7,14 +17,6 @@ use crate::messages::*;
 use crate::not_implemented::not_implemented;
 use crate::users::*;
 use crate::ws::*;
-use actix_web::http::StatusCode;
-use actix_web::{web, App, HttpResponse, HttpServer};
-use ferrischat_auth::init_auth;
-use ferrischat_db::load_db;
-use ferrischat_macros::expand_version;
-use ferrischat_redis::load_redis;
-use ferrischat_ws::{init_ws_server, preload_ws};
-use ring::rand::{SecureRandom, SystemRandom};
 
 #[allow(clippy::expect_used)]
 pub async fn entrypoint() {
@@ -179,6 +181,14 @@ pub async fn entrypoint() {
             .route(
                 expand_version!("guilds/{guild_id}/members/{user_id}/role/{role_id}"),
                 web::delete().to(roles::remove_member_role),
+            )
+            .route(
+                expand_version!("verify"),
+                web::post().to(send_verification_email),
+            )
+            .route(
+                expand_version!("verify/{token}"),
+                web::get().to(verify_email),
             )
             .route(
                 expand_version!("teapot"),

--- a/ferrischat_webserver/src/users/mod.rs
+++ b/ferrischat_webserver/src/users/mod.rs
@@ -2,8 +2,10 @@ mod create_user;
 mod delete_user;
 mod edit_user;
 mod get_user;
+mod verify_user;
 
 pub use create_user::*;
 pub use delete_user::*;
 pub use edit_user::*;
 pub use get_user::*;
+pub use verify_user::*;

--- a/ferrischat_webserver/src/users/verify_user.rs
+++ b/ferrischat_webserver/src/users/verify_user.rs
@@ -9,153 +9,24 @@ use simd_json::ValueAccess;
 use sqlx::Error;
 
 use ferrischat_redis::{redis::AsyncCommands, REDIS_MANAGER};
-
 /// POST /v0/verify
-pub async fn send_verification_email(
-    req: HttpRequest,
-    auth: crate::Authorization,
-) -> impl Responder {
-    let authorized_user = auth.0;
-    match sqlx::query!("SELECT email FROM users WHERE id = $1", authorized_user)
-        .fetch_optional(db)
-        .await
-    {
-        Ok(email) => {
-            let user_email = email.email;
-        }
-        Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
-            reason: format!("Database returned a error: {}", e),
-        }),
-    }
-    let checker_input = CheckEmailInput::new(vec![user_email.into()]);
-    let checked_email = check_email(&checker_input).await;
-    if checked_email[0].syntax.is_valid_syntax {
-        if checked_email[0].is_reachable == Reachable::Safe
-            || checked_email[0].is_reachable == Reachable::Risky
-            || checked_email[0].is_reachable == Reachable::Unknown
-        {
+pub async fn send_verification_email(req: HttpRequest,auth: crate::Authorization) -> impl Responder { let authorized_user = auth.0;let user_email = match sqlx::query!("SELECT email FROM users WHERE id = $1", authorized_user).fetch_optional(db).await { Ok(email) => email.email, Err(e) => { return HttpResponse::InternalServerError().json(InternalServerErrorJson { reason: format!("Database returned a error: {}", e), }) } };let checker_input = CheckEmailInput::new(vec![user_email.into()]);let checked_email = check_email(&checker_input).await;if checked_email[0].syntax.is_valid_syntax { if checked_email[0].is_reachable == Reachable::Safe || checked_email[0].is_reachable == Reachable::Risky || checked_email[0].is_reachable == Reachable::Unknown {
             // get configs
-            let mut redis = REDIS_MANAGER
-                .get()
-                .expect("redis not initialized: call load_redis before this")
-                .clone();
-            match host = redis.get("config:email:host").get::<String, String>().await {
-                Ok(_) => password,
-                Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
-                    reason: format!("No SMTP server host set."),
-                }),
-            }
-            match host = redis
-                .get("config:email:username")
-                .get::<String, String>()
-                .await
-            {
-                Ok(_) => password,
-                Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
-                    reason: format!("No SMTP server username set."),
-                }),
-            }
-            match password = redis
-                .get("config:email:password")
-                .get::<String, String>()
-                .await
-            {
-                Ok(_) => password,
-                Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
-                    reason: format!("No SMTP server password set."),
-                }),
-            }
-            let token = match ferrischat_webserver::auth::generate_random_bits() {
-                Some(b) => base64::encode_config(b, base64::URL_SAFE),
-                None => {
-                    return HttpResponse::InternalServerError().json(InternalServerErrorJson {
-                        reason: "failed to generate random bits for token generation".to_string(),
-                    })
-                }
-            };
-            match message = Message::builder()
-                .from("Ferris <verification@ferris.chat>".parse().unwrap())
-                .reply_to("Ferris <hello@ferris.chat>".parse().unwrap())
-                .to(user_email.parse().unwrap())
-                .subject("FerrisChat Email Verification")
-                .body(String::from(format!(
-                    "Welcome to FerrisChat!<br><a href=\"https://api.ferris.chat/v0/verify/{}\">Click here to verify \
+            let mut redis = REDIS_MANAGER.get().expect("redis not initialized: call load_redis before this").clone();match host = redis.get::<String, String>("config:email:host".to_string()).await { Ok(_) => password, Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson { reason: format!("No SMTP server host set."), }), }match host = redis.get::<String, String>("config:email:username".to_string()).await { Ok(_) => password, Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson { reason: format!("No SMTP server username set."), }), }match password = redis.get::<String, String>("config:email:password".to_string()).await { Ok(_) => password, Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson { reason: format!("No SMTP server password set."), }), }let token = match ferrischat_webserver::auth::generate_random_bits() { Some(b) => base64::encode_config(b, base64::URL_SAFE), None => { return HttpResponse::InternalServerError().json(InternalServerErrorJson { reason: "failed to generate random bits for token generation".to_string(), }); } };match message = Message::builder().from("Ferris <verification@ferris.chat>".parse().unwrap()).reply_to("Ferris <hello@ferris.chat>".parse().unwrap()).to(user_email.parse().unwrap()).subject("FerrisChat Email Verification").body(String::from(format!("Welcome to FerrisChat!<br><a href=\"https://api.ferris.chat/v0/verify/{}\">Click here to verify \
         your email!</a> (expires in 1 hour) <br><br> If you don't know what this is, reset your token and change \
-        your password ASAP.",
-                    token
-                ))) {
-                Ok(_) => message,
-                Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
-                    reason: format!(
-                        "This should not have happened. Submit a bug report on \
-                    https://github.com/ferrischat/server/issues with the error `{}`",
-                        e
-                    ),
-                }),
-            }
+        your password ASAP.", token))) { Ok(_) => message, Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson { reason: format!("This should not have happened. Submit a bug report on \
+                    https://github.com/ferrischat/server/issues with the error `{}`", e), }), }
 
             let mail_creds = Credentials::new(username.to_string(), password.to_string());
 
-            // Open a remote connection to gmail
-            match mailer = SmtpTransport::relay(host.as_str().unwrap())
-                .credentials(mail_creds)
-                .build()
-            {
-                Ok(_) => mailer,
-                Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
-                    reason: format!(
-                        "Error creating SMTP transport! Please submit a bug report on \
-                    https://github.com/ferrischat/server/issues with the error `{}`",
-                        e
-                    ),
-                }),
-            }
+            // Open a remote connection to the mailserver
+            match mailer = SmtpTransport::relay(host.as_str().unwrap()).credentials(mail_creds).build() { Ok(_) => mailer, Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson { reason: format!("Error creating SMTP transport! Please submit a bug report on \
+                    https://github.com/ferrischat/server/issues with the error `{}`", e), }), }
 
             // Send the email
-            match mailer.send(&message) {
-                Ok(_) => HttpResponse::Ok().finish(),
-                Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
-                    reason: format!(
-                        "Mailer failed to send correctly! Please submit a bug report \
-                    on https://github.com/ferrischat/server/issues with the error `{}`",
-                        e
-                    ),
-                }),
-            }
+            match mailer.send(&message) { Ok(_) => HttpResponse::Ok().finish(), Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson { reason: format!("Mailer failed to send correctly! Please submit a bug report \
+                    on https://github.com/ferrischat/server/issues with the error `{}`", e), }),}
             // writes the token to redis
-            let r = redis
-                .set_ex::<String, String, String>(
-                    format!("email:tokens:{}", token),
-                    user_email,
-                    86400,
-                )
-                .await;
-        } else {
-            HttpResponse::Conflict().json(InternalServerErrorJson {
-                reason: format!("Email deemed unsafe to send to. Is it a real email?"),
-            })
-        }
-    } else {
-        HttpResponse::Conflict().json(InternalServerErrorJson {
-            reason: format!("Email {} is invalid.", user_email),
-        })
-    }
-}
-
+            let r = redis.set_ex::<String, String, String>(format!("email:tokens:{}", token), user_email, 86400,).await;}else{HttpResponse::Conflict().json(InternalServerErrorJson {reason: format!("Email deemed unsafe to send to. Is it a real email?"),})}}else{HttpResponse::Conflict().json(InternalServerErrorJson {reason: format!("Email {} is invalid.", user_email),})}}
 /// GET /v0/verify/{token}
-pub async fn verify_email(req: HttpRequest, path: actix_web::web::Path<String>) -> impl Responder {
-    let mut redis = REDIS_MANAGER
-        .get()
-        .expect("redis not initialized: call load_redis before this")
-        .clone();
-    match host = redis
-        .get(format!("email:tokens:{}", path.into_inner()))
-        .get::<String, String>()
-        .await
-    {
-        Ok(_) => HttpResponse::Ok().body("Verified email. You can close this page."),
-        Err(e) => HttpResponse::NotFound().json(NotFoundJson {
-            message: format!("This token has expired or was not found.")
-        }),
-    }
-}
+pub async fn verify_email(req: HttpRequest, path: actix_web::web::Path<String>) -> impl Responder{let mut redis = REDIS_MANAGER.get().expect("redis not initialized: call load_redis before this").clone();match host = redis.get(format!("email:tokens:{}",path.into_inner())).get::<String,String>().await{Ok(_)=>HttpResponse::Ok().body("Verified email. You can close this page."),Err(_)=>HttpResponse::NotFound().json(NotFoundJson{message: format!("This token has expired or was not found."),}),}if let Err(e) = sqlx::query!("UPDATE users SET verified = true WHERE email = $1",authorized_user).fetch_optional(db).await{HttpResponse::InternalServerError().json(InternalServerErrorJson {reason: format!("Database returned a error: {}", e), }) } }

--- a/ferrischat_webserver/src/users/verify_user.rs
+++ b/ferrischat_webserver/src/users/verify_user.rs
@@ -65,7 +65,7 @@ pub async fn send_verification_email(
                     reason: format!("No SMTP server password set."),
                 }),
             }
-            let token = match ferrischat_webserver::auth::generate_random_bits() {
+            let token = match crate::auth::generate_random_bits() {
                 Some(b) => base64::encode_config(b, base64::URL_SAFE),
                 None => {
                     return HttpResponse::InternalServerError().json(InternalServerErrorJson {

--- a/ferrischat_webserver/src/users/verify_user.rs
+++ b/ferrischat_webserver/src/users/verify_user.rs
@@ -39,33 +39,33 @@ pub async fn send_verification_email(
                 .get()
                 .expect("redis not initialized: call load_redis before this")
                 .clone();
-            match host = redis
+            let host = match redis
                 .get::<String, String>("config:email:host".to_string())
                 .await
             {
-                Ok(_) => password,
+                Ok(r) => r,
                 Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
                     reason: format!("No SMTP server host set."),
                 }),
-            }
-            match host = redis
+            };
+            let username = match redis
                 .get::<String, String>("config:email:username".to_string())
                 .await
             {
-                Ok(_) => password,
+                Ok(r) => r,
                 Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
                     reason: format!("No SMTP server username set."),
                 }),
-            }
-            match password = redis
+            };
+            let password = match redis
                 .get::<String, String>("config:email:password".to_string())
                 .await
             {
-                Ok(_) => password,
+                Ok(r) => r,
                 Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
                     reason: format!("No SMTP server password set."),
                 }),
-            }
+            };
             let token = match crate::auth::generate_random_bits() {
                 Some(b) => base64::encode_config(b, base64::URL_SAFE),
                 None => {
@@ -82,11 +82,11 @@ pub async fn send_verification_email(
             let mail_creds = Credentials::new(username.to_string(), password.to_string());
 
             // Open a remote connection to the mailserver
-            match mailer = SmtpTransport::relay(host.as_string())
+            let mailer = match SmtpTransport::relay(host.as_string())
                 .credentials(mail_creds)
                 .build()
             {
-                Ok(_) => mailer,
+                Ok(m) => m,
                 Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
                     reason: format!(
                         "Error creating SMTP transport! Please submit a bug report on \

--- a/ferrischat_webserver/src/users/verify_user.rs
+++ b/ferrischat_webserver/src/users/verify_user.rs
@@ -15,7 +15,7 @@ pub async fn send_verification_email(
     auth: crate::Authorization,
 ) -> impl Responder {
     let authorized_user = auth.0;
-    let user_email = match sqlx::query!("SELECT email FROM users WHERE id = $1", authorized_user)
+    let user_email = match sqlx::query!("SELECT email FROM users WHERE id = $1", u128_to_bigdecimal!(authorized_user))
         .fetch_optional(db)
         .await
     {

--- a/ferrischat_webserver/src/users/verify_user.rs
+++ b/ferrischat_webserver/src/users/verify_user.rs
@@ -148,7 +148,7 @@ pub async fn verify_email(req: HttpRequest, path: actix_web::web::Path<String>) 
         .expect("redis not initialized: call load_redis before this")
         .clone();
     let email = match redis
-        .get::<String, Option<String>>(redis_key)
+        .get::<String, Option<String>>(redis_key.clone())
         .await
     {
         Ok(Some(email)) => {

--- a/ferrischat_webserver/src/users/verify_user.rs
+++ b/ferrischat_webserver/src/users/verify_user.rs
@@ -44,7 +44,7 @@ pub async fn send_verification_email(
                 .await
             {
                 Ok(r) => r,
-                Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
+                Err(e) => return HttpResponse::InternalServerError().json(InternalServerErrorJson {
                     reason: format!("No SMTP server host set."),
                 }),
             };
@@ -53,7 +53,7 @@ pub async fn send_verification_email(
                 .await
             {
                 Ok(r) => r,
-                Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
+                Err(e) => return HttpResponse::InternalServerError().json(InternalServerErrorJson {
                     reason: format!("No SMTP server username set."),
                 }),
             };
@@ -62,7 +62,7 @@ pub async fn send_verification_email(
                 .await
             {
                 Ok(r) => r,
-                Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
+                Err(e) => return HttpResponse::InternalServerError().json(InternalServerErrorJson {
                     reason: format!("No SMTP server password set."),
                 }),
             };
@@ -71,7 +71,7 @@ pub async fn send_verification_email(
                 None => {
                     return HttpResponse::InternalServerError().json(InternalServerErrorJson {
                         reason: "failed to generate random bits for token generation".to_string(),
-                    });
+                    })
                 }
             };
             match message = Message::builder().from("Ferris <verification@ferris.chat>".parse().unwrap()).reply_to("Ferris <hello@ferris.chat>".parse().unwrap()).to(user_email.parse().unwrap()).subject("FerrisChat Email Verification").body(String::from(format!("Welcome to FerrisChat!<br><a href=\"https://api.ferris.chat/v0/verify/{}\">Click here to verify \
@@ -87,14 +87,14 @@ pub async fn send_verification_email(
                 .build()
             {
                 Ok(m) => m,
-                Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
+                Err(e) => return HttpResponse::InternalServerError().json(InternalServerErrorJson {
                     reason: format!(
                         "Error creating SMTP transport! Please submit a bug report on \
                     https://github.com/ferrischat/server/issues with the error `{}`",
                         e
                     ),
                 }),
-            }
+            };
 
             // Send the email
             if let Err(e) = mailer.send(&message) {

--- a/ferrischat_webserver/src/users/verify_user.rs
+++ b/ferrischat_webserver/src/users/verify_user.rs
@@ -95,10 +95,9 @@ pub async fn send_verification_email(
 
             // Open a remote connection to the mailserver
             let mailer = match SmtpTransport::relay(host.as_str())
-                .credentials(mail_creds)
-                .build()
             {
-                Ok(m) => m,
+                Ok(m) => m.credentials(mail_creds)
+                .build(),
                 Err(e) => return HttpResponse::InternalServerError().json(InternalServerErrorJson {
                     reason: format!(
                         "Error creating SMTP transport! Please submit a bug report on \

--- a/ferrischat_webserver/src/users/verify_user.rs
+++ b/ferrischat_webserver/src/users/verify_user.rs
@@ -76,7 +76,7 @@ pub async fn send_verification_email(
                     })
                 }
             };
-            match Message::builder()
+            let message = match Message::builder()
                 .from("Ferris <verification@ferris.chat>".parse().unwrap())
                 .reply_to("Ferris <hello@ferris.chat>".parse().unwrap())
                 .to(user_email.parse().unwrap())
@@ -84,7 +84,7 @@ pub async fn send_verification_email(
                 .body(String::from(format!("Welcome to FerrisChat!<br><a href=\"https://api.ferris.chat/v0/verify/{}\">Click here to verify \
         your email!</a> (expires in 1 hour) <br><br> If you don't know what this is, reset your token and change \
         your password ASAP.", token))) {
-                Ok(_) => message,
+                Ok(m) => m,
                 Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
                     reason: format!("This should not have happened. Submit a bug report on \
                     https://github.com/ferrischat/server/issues with the error `{}`", e),

--- a/ferrischat_webserver/src/users/verify_user.rs
+++ b/ferrischat_webserver/src/users/verify_user.rs
@@ -10,9 +10,70 @@ use sqlx::Error;
 
 use ferrischat_redis::{redis::AsyncCommands, REDIS_MANAGER};
 /// POST /v0/verify
-pub async fn send_verification_email(req: HttpRequest,auth: crate::Authorization) -> impl Responder { let authorized_user = auth.0;let user_email = match sqlx::query!("SELECT email FROM users WHERE id = $1", authorized_user).fetch_optional(db).await { Ok(email) => email.email, Err(e) => { return HttpResponse::InternalServerError().json(InternalServerErrorJson { reason: format!("Database returned a error: {}", e), }) } };let checker_input = CheckEmailInput::new(vec![user_email.into()]);let checked_email = check_email(&checker_input).await;if checked_email[0].syntax.is_valid_syntax { if checked_email[0].is_reachable == Reachable::Safe || checked_email[0].is_reachable == Reachable::Risky || checked_email[0].is_reachable == Reachable::Unknown {
+pub async fn send_verification_email(
+    req: HttpRequest,
+    auth: crate::Authorization,
+) -> impl Responder {
+    let authorized_user = auth.0;
+    let user_email = match sqlx::query!("SELECT email FROM users WHERE id = $1", authorized_user)
+        .fetch_optional(db)
+        .await
+    {
+        Ok(email) => email.email,
+        Err(e) => {
+            return HttpResponse::InternalServerError().json(InternalServerErrorJson {
+                reason: format!("Database returned a error: {}", e),
+            })
+        }
+    };
+    let checker_input = CheckEmailInput::new(vec![user_email.into()]);
+    let checked_email = check_email(&checker_input).await;
+    if checked_email[0].syntax.is_valid_syntax {
+        if checked_email[0].is_reachable == Reachable::Safe
+            || checked_email[0].is_reachable == Reachable::Risky
+            || checked_email[0].is_reachable == Reachable::Unknown
+        {
             // get configs
-            let mut redis = REDIS_MANAGER.get().expect("redis not initialized: call load_redis before this").clone();match host = redis.get::<String, String>("config:email:host".to_string()).await { Ok(_) => password, Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson { reason: format!("No SMTP server host set."), }), }match host = redis.get::<String, String>("config:email:username".to_string()).await { Ok(_) => password, Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson { reason: format!("No SMTP server username set."), }), }match password = redis.get::<String, String>("config:email:password".to_string()).await { Ok(_) => password, Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson { reason: format!("No SMTP server password set."), }), }let token = match ferrischat_webserver::auth::generate_random_bits() { Some(b) => base64::encode_config(b, base64::URL_SAFE), None => { return HttpResponse::InternalServerError().json(InternalServerErrorJson { reason: "failed to generate random bits for token generation".to_string(), }); } };match message = Message::builder().from("Ferris <verification@ferris.chat>".parse().unwrap()).reply_to("Ferris <hello@ferris.chat>".parse().unwrap()).to(user_email.parse().unwrap()).subject("FerrisChat Email Verification").body(String::from(format!("Welcome to FerrisChat!<br><a href=\"https://api.ferris.chat/v0/verify/{}\">Click here to verify \
+            let mut redis = REDIS_MANAGER
+                .get()
+                .expect("redis not initialized: call load_redis before this")
+                .clone();
+            match host = redis
+                .get::<String, String>("config:email:host".to_string())
+                .await
+            {
+                Ok(_) => password,
+                Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
+                    reason: format!("No SMTP server host set."),
+                }),
+            }
+            match host = redis
+                .get::<String, String>("config:email:username".to_string())
+                .await
+            {
+                Ok(_) => password,
+                Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
+                    reason: format!("No SMTP server username set."),
+                }),
+            }
+            match password = redis
+                .get::<String, String>("config:email:password".to_string())
+                .await
+            {
+                Ok(_) => password,
+                Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
+                    reason: format!("No SMTP server password set."),
+                }),
+            }
+            let token = match ferrischat_webserver::auth::generate_random_bits() {
+                Some(b) => base64::encode_config(b, base64::URL_SAFE),
+                None => {
+                    return HttpResponse::InternalServerError().json(InternalServerErrorJson {
+                        reason: "failed to generate random bits for token generation".to_string(),
+                    });
+                }
+            };
+            match message = Message::builder().from("Ferris <verification@ferris.chat>".parse().unwrap()).reply_to("Ferris <hello@ferris.chat>".parse().unwrap()).to(user_email.parse().unwrap()).subject("FerrisChat Email Verification").body(String::from(format!("Welcome to FerrisChat!<br><a href=\"https://api.ferris.chat/v0/verify/{}\">Click here to verify \
         your email!</a> (expires in 1 hour) <br><br> If you don't know what this is, reset your token and change \
         your password ASAP.", token))) { Ok(_) => message, Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson { reason: format!("This should not have happened. Submit a bug report on \
                     https://github.com/ferrischat/server/issues with the error `{}`", e), }), }
@@ -20,13 +81,75 @@ pub async fn send_verification_email(req: HttpRequest,auth: crate::Authorization
             let mail_creds = Credentials::new(username.to_string(), password.to_string());
 
             // Open a remote connection to the mailserver
-            match mailer = SmtpTransport::relay(host.as_str().unwrap()).credentials(mail_creds).build() { Ok(_) => mailer, Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson { reason: format!("Error creating SMTP transport! Please submit a bug report on \
-                    https://github.com/ferrischat/server/issues with the error `{}`", e), }), }
+            match mailer = SmtpTransport::relay(host.as_str().unwrap())
+                .credentials(mail_creds)
+                .build()
+            {
+                Ok(_) => mailer,
+                Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
+                    reason: format!(
+                        "Error creating SMTP transport! Please submit a bug report on \
+                    https://github.com/ferrischat/server/issues with the error `{}`",
+                        e
+                    ),
+                }),
+            }
 
             // Send the email
-            match mailer.send(&message) { Ok(_) => HttpResponse::Ok().finish(), Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson { reason: format!("Mailer failed to send correctly! Please submit a bug report \
-                    on https://github.com/ferrischat/server/issues with the error `{}`", e), }),}
+            match mailer.send(&message) {
+                Ok(_) => HttpResponse::Ok().finish(),
+                Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
+                    reason: format!(
+                        "Mailer failed to send correctly! Please submit a bug report \
+                    on https://github.com/ferrischat/server/issues with the error `{}`",
+                        e
+                    ),
+                }),
+            }
             // writes the token to redis
-            let r = redis.set_ex::<String, String, String>(format!("email:tokens:{}", token), user_email, 86400,).await;}else{HttpResponse::Conflict().json(InternalServerErrorJson {reason: format!("Email deemed unsafe to send to. Is it a real email?"),})}}else{HttpResponse::Conflict().json(InternalServerErrorJson {reason: format!("Email {} is invalid.", user_email),})}}
+            let r = redis
+                .set_ex::<String, String, String>(
+                    format!("email:tokens:{}", token),
+                    user_email,
+                    86400,
+                )
+                .await;
+        } else {
+            HttpResponse::Conflict().json(InternalServerErrorJson {
+                reason: format!("Email deemed unsafe to send to. Is it a real email?"),
+            })
+        }
+    } else {
+        HttpResponse::Conflict().json(InternalServerErrorJson {
+            reason: format!("Email {} is invalid.", user_email),
+        })
+    }
+}
 /// GET /v0/verify/{token}
-pub async fn verify_email(req: HttpRequest, path: actix_web::web::Path<String>) -> impl Responder{let mut redis = REDIS_MANAGER.get().expect("redis not initialized: call load_redis before this").clone();match host = redis.get(format!("email:tokens:{}",path.into_inner())).get::<String,String>().await{Ok(_)=>HttpResponse::Ok().body("Verified email. You can close this page."),Err(_)=>HttpResponse::NotFound().json(NotFoundJson{message: format!("This token has expired or was not found."),}),}if let Err(e) = sqlx::query!("UPDATE users SET verified = true WHERE email = $1",authorized_user).fetch_optional(db).await{HttpResponse::InternalServerError().json(InternalServerErrorJson {reason: format!("Database returned a error: {}", e), }) } }
+pub async fn verify_email(req: HttpRequest, path: actix_web::web::Path<String>) -> impl Responder {
+    let mut redis = REDIS_MANAGER
+        .get()
+        .expect("redis not initialized: call load_redis before this")
+        .clone();
+    match host = redis
+        .get(format!("email:tokens:{}", path.into_inner()))
+        .get::<String, String>()
+        .await
+    {
+        Ok(_) => HttpResponse::Ok().body("Verified email. You can close this page."),
+        Err(_) => HttpResponse::NotFound().json(NotFoundJson {
+            message: format!("This token has expired or was not found."),
+        }),
+    }
+    if let Err(e) = sqlx::query!(
+        "UPDATE users SET verified = true WHERE email = $1",
+        authorized_user
+    )
+    .fetch_optional(db)
+    .await
+    {
+        HttpResponse::InternalServerError().json(InternalServerErrorJson {
+            reason: format!("Database returned a error: {}", e),
+        })
+    }
+}

--- a/ferrischat_webserver/src/users/verify_user.rs
+++ b/ferrischat_webserver/src/users/verify_user.rs
@@ -101,7 +101,7 @@ pub async fn send_verification_email(auth: crate::Authorization) -> impl Respond
             };
 
             // Send the email
-            if let Err(e) = mailer.send(&message).await {
+            if let Err(e) = mailer.send(message).await {
                 return HttpResponse::InternalServerError().json(InternalServerErrorJson {
                     reason: format!(
                         "Mailer failed to send correctly! Please submit a bug report \

--- a/ferrischat_webserver/src/users/verify_user.rs
+++ b/ferrischat_webserver/src/users/verify_user.rs
@@ -1,0 +1,161 @@
+use actix_web::{web::Json, HttpRequest, HttpResponse, Responder};
+use check_if_email_exists::{check_email, CheckEmailInput, Reachable};
+use ferrischat_common::types::{
+    Guild, GuildFlags, InternalServerErrorJson, NotFoundJson, User, UserFlags,
+};
+use lettre::transport::smtp::authentication::Credentials;
+use lettre::{Message, SmtpTransport, Transport};
+use simd_json::ValueAccess;
+use sqlx::Error;
+
+use ferrischat_redis::{redis::AsyncCommands, REDIS_MANAGER};
+
+/// POST /v0/verify
+pub async fn send_verification_email(
+    req: HttpRequest,
+    auth: crate::Authorization,
+) -> impl Responder {
+    let authorized_user = auth.0;
+    match sqlx::query!("SELECT email FROM users WHERE id = $1", authorized_user)
+        .fetch_optional(db)
+        .await
+    {
+        Ok(email) => {
+            let user_email = email.email;
+        }
+        Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
+            reason: format!("Database returned a error: {}", e),
+        }),
+    }
+    let checker_input = CheckEmailInput::new(vec![user_email.into()]);
+    let checked_email = check_email(&checker_input).await;
+    if checked_email[0].syntax.is_valid_syntax {
+        if checked_email[0].is_reachable == Reachable::Safe
+            || checked_email[0].is_reachable == Reachable::Risky
+            || checked_email[0].is_reachable == Reachable::Unknown
+        {
+            // get configs
+            let mut redis = REDIS_MANAGER
+                .get()
+                .expect("redis not initialized: call load_redis before this")
+                .clone();
+            match host = redis.get("config:email:host").get::<String, String>().await {
+                Ok(_) => password,
+                Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
+                    reason: format!("No SMTP server host set."),
+                }),
+            }
+            match host = redis
+                .get("config:email:username")
+                .get::<String, String>()
+                .await
+            {
+                Ok(_) => password,
+                Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
+                    reason: format!("No SMTP server username set."),
+                }),
+            }
+            match password = redis
+                .get("config:email:password")
+                .get::<String, String>()
+                .await
+            {
+                Ok(_) => password,
+                Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
+                    reason: format!("No SMTP server password set."),
+                }),
+            }
+            let token = match ferrischat_webserver::auth::generate_random_bits() {
+                Some(b) => base64::encode_config(b, base64::URL_SAFE),
+                None => {
+                    return HttpResponse::InternalServerError().json(InternalServerErrorJson {
+                        reason: "failed to generate random bits for token generation".to_string(),
+                    })
+                }
+            };
+            match message = Message::builder()
+                .from("Ferris <verification@ferris.chat>".parse().unwrap())
+                .reply_to("Ferris <hello@ferris.chat>".parse().unwrap())
+                .to(user_email.parse().unwrap())
+                .subject("FerrisChat Email Verification")
+                .body(String::from(format!(
+                    "Welcome to FerrisChat!<br><a href=\"https://api.ferris.chat/v0/verify/{}\">Click here to verify \
+        your email!</a> (expires in 1 hour) <br><br> If you don't know what this is, reset your token and change \
+        your password ASAP.",
+                    token
+                ))) {
+                Ok(_) => message,
+                Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
+                    reason: format!(
+                        "This should not have happened. Submit a bug report on \
+                    https://github.com/ferrischat/server/issues with the error `{}`",
+                        e
+                    ),
+                }),
+            }
+
+            let mail_creds = Credentials::new(username.to_string(), password.to_string());
+
+            // Open a remote connection to gmail
+            match mailer = SmtpTransport::relay(host.as_str().unwrap())
+                .credentials(mail_creds)
+                .build()
+            {
+                Ok(_) => mailer,
+                Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
+                    reason: format!(
+                        "Error creating SMTP transport! Please submit a bug report on \
+                    https://github.com/ferrischat/server/issues with the error `{}`",
+                        e
+                    ),
+                }),
+            }
+
+            // Send the email
+            match mailer.send(&message) {
+                Ok(_) => HttpResponse::Ok().finish(),
+                Err(e) => HttpResponse::InternalServerError().json(InternalServerErrorJson {
+                    reason: format!(
+                        "Mailer failed to send correctly! Please submit a bug report \
+                    on https://github.com/ferrischat/server/issues with the error `{}`",
+                        e
+                    ),
+                }),
+            }
+            // writes the token to redis
+            let r = redis
+                .set_ex::<String, String, String>(
+                    format!("email:tokens:{}", token),
+                    user_email,
+                    86400,
+                )
+                .await;
+        } else {
+            HttpResponse::Conflict().json(InternalServerErrorJson {
+                reason: format!("Email deemed unsafe to send to. Is it a real email?"),
+            })
+        }
+    } else {
+        HttpResponse::Conflict().json(InternalServerErrorJson {
+            reason: format!("Email {} is invalid.", user_email),
+        })
+    }
+}
+
+/// GET /v0/verify/{token}
+pub async fn verify_email(req: HttpRequest, path: actix_web::web::Path<String>) -> impl Responder {
+    let mut redis = REDIS_MANAGER
+        .get()
+        .expect("redis not initialized: call load_redis before this")
+        .clone();
+    match host = redis
+        .get(format!("email:tokens:{}", path.into_inner()))
+        .get::<String, String>()
+        .await
+    {
+        Ok(_) => HttpResponse::Ok().body("Verified email. You can close this page."),
+        Err(e) => HttpResponse::NotFound().json(NotFoundJson {
+            message: format!("This token has expired or was not found.")
+        }),
+    }
+}

--- a/ferrischat_webserver/src/users/verify_user.rs
+++ b/ferrischat_webserver/src/users/verify_user.rs
@@ -27,7 +27,7 @@ pub async fn send_verification_email(
             })
         }
     };
-    let checker_input = CheckEmailInput::new(vec![user_email.into()]);
+    let checker_input = CheckEmailInput::new(vec![user_email.clone().into()]);
     let checked_email = check_email(&checker_input).await;
     if checked_email[0].syntax.is_valid_syntax {
         if checked_email[0].is_reachable == Reachable::Safe

--- a/ferrischat_webserver/src/users/verify_user.rs
+++ b/ferrischat_webserver/src/users/verify_user.rs
@@ -157,6 +157,7 @@ pub async fn verify_email(req: HttpRequest, path: actix_web::web::Path<String>) 
             });
         }
     }
+    let db = get_db_or_fail!();
     if let Err(e) = sqlx::query!(
         "UPDATE users SET verified = true WHERE email = $1",
         authorized_user

--- a/ferrischat_webserver/src/users/verify_user.rs
+++ b/ferrischat_webserver/src/users/verify_user.rs
@@ -16,7 +16,7 @@ pub async fn send_verification_email(
 ) -> impl Responder {
     let authorized_user = auth.0;
     let user_email = match sqlx::query!("SELECT email FROM users WHERE id = $1", u128_to_bigdecimal!(authorized_user))
-        .fetch_optional(db)
+        .fetch_one(db)
         .await
     {
         Ok(email) => email.email,

--- a/ferrischat_webserver/src/users/verify_user.rs
+++ b/ferrischat_webserver/src/users/verify_user.rs
@@ -14,6 +14,7 @@ pub async fn send_verification_email(
     req: HttpRequest,
     auth: crate::Authorization,
 ) -> impl Responder {
+    let db = get_db_or_fail!();
     let authorized_user = auth.0;
     let user_email = match sqlx::query!("SELECT email FROM users WHERE id = $1", u128_to_bigdecimal!(authorized_user))
         .fetch_one(db)

--- a/ferrischat_webserver/src/users/verify_user.rs
+++ b/ferrischat_webserver/src/users/verify_user.rs
@@ -81,7 +81,7 @@ pub async fn send_verification_email(
             let mail_creds = Credentials::new(username.to_string(), password.to_string());
 
             // Open a remote connection to the mailserver
-            match mailer = SmtpTransport::relay(host.as_str().unwrap())
+            match mailer = SmtpTransport::relay(host.as_string())
                 .credentials(mail_creds)
                 .build()
             {

--- a/ferrischat_webserver/src/users/verify_user.rs
+++ b/ferrischat_webserver/src/users/verify_user.rs
@@ -82,7 +82,7 @@ pub async fn send_verification_email(
             let mail_creds = Credentials::new(username.to_string(), password.to_string());
 
             // Open a remote connection to the mailserver
-            let mailer = match SmtpTransport::relay(host.as_string())
+            let mailer = match SmtpTransport::relay(host.as_str())
                 .credentials(mail_creds)
                 .build()
             {

--- a/migrations/20211116070235_add_verified_column.sql
+++ b/migrations/20211116070235_add_verified_column.sql
@@ -1,0 +1,2 @@
+-- Add migration script here
+ALTER TABLE users ADD COLUMN verified BOOLEAN DEFAULT false;


### PR DESCRIPTION
Enables email verification for Ferrischat. posting /v0/verify with an authorization header will send your user account's email a message with a link that can be clicked. clicking that link verifies your email.